### PR TITLE
Fix docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 .PHONY: docs
 docs:
 	mkdir -p docs/sdk docs/cli
-	gomarkdoc ./sdk --output docs/sdk/README.md
+	go run github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest ./sdk --output docs/sdk/README.md
 	go run ./cmd/fieldctl gen-docs --dir docs/cli --format markdown
 
 # code generation


### PR DESCRIPTION
## Summary
- fix the `make docs` task so it installs gomarkdoc via `go run`

## Testing
- `gofmt -w $(git ls-files '*.go') && git diff --exit-code`
- `go test ./...`
- `make docs`

------
https://chatgpt.com/codex/tasks/task_e_686139a7e4ec83288cb29425e47739f9