### PR TITLE
Add build target and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ go.work.sum
 
 # log files
 *.log
+bin/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ test:
 	@go test -v ./... -coverprofile=coverage.out
 	@go tool cover -html=coverage.out -o coverage.html
 
+.PHONY: build
+build:
+	@mkdir -p bin
+	go build -o bin/fieldctl ./cmd/fieldctl
+	go build -o bin/api-server ./cmd/api-server
+
 # docs generation
 .PHONY: docs
 docs:
@@ -25,12 +31,12 @@ docs:
 # code generation
 .PHONY: generate
 generate:
-	       fieldctl gen go --pkg=models --out=internal/models/cf_post.go --table=posts
-	       fieldctl gen registry --src internal/models/*.go --out registry.yaml --merge
+	fieldctl gen go --pkg=models --out=internal/models/cf_post.go --table=posts
+	fieldctl gen registry --src internal/models/*.go --out registry.yaml --merge
 
 .PHONY: openapi
 openapi:
-               go run ./cmd/api-server -openapi dist/openapi.json
+	go run ./cmd/api-server -openapi dist/openapi.json
 
 .PHONY: db-init
 db-init:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 [![Docs](https://img.shields.io/badge/docs-latest-blue)](https://faciam-dev.github.io/gcfm/)
 A model system that provides custom fields
 
+## Build
+
+Run `make build` to compile the CLI and API server. Binaries will be placed in
+the `bin` directory.
+
+
 ## fieldctl scan
 
 Scan existing database tables and store the metadata in the `custom_fields` table.


### PR DESCRIPTION
## Summary
- ignore generated `bin/` directory
- create a `build` target in the Makefile to compile `fieldctl` and `api-server`
- document how to build the project

## Testing
- `make build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6861785955e88328b310066ba72b6961