### PR TITLE
Fix MySQL migration table detection

### DIFF
--- a/internal/customfield/migrator/migrator.go
+++ b/internal/customfield/migrator/migrator.go
@@ -173,7 +173,7 @@ func isTableMissing(err error) bool {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "does not exist") || strings.Contains(msg, "no such table") || strings.Contains(msg, "undefined table")
+	return strings.Contains(msg, "does not exist") || strings.Contains(msg, "doesn't exist") || strings.Contains(msg, "no such table") || strings.Contains(msg, "undefined table")
 }
 
 // SQLForRange returns SQL statements needed to migrate from->to.


### PR DESCRIPTION
## Summary
- handle MySQL "doesn't exist" error message when checking if the registry version table is missing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68621fe63d408328ba68edadc3182998