### PR TITLE
Add ID to custom_fields

### DIFF
--- a/dist/openapi.json
+++ b/dist/openapi.json
@@ -260,6 +260,10 @@
           "Display": {
             "$ref": "#/components/schemas/DisplayMeta"
           },
+          "ID": {
+            "format": "int64",
+            "type": "integer"
+          },
           "Nullable": {
             "type": "boolean"
           },
@@ -277,6 +281,7 @@
           }
         },
         "required": [
+          "ID",
           "TableName",
           "ColumnName",
           "DataType",

--- a/internal/customfield/migrator/migrations_embed.go
+++ b/internal/customfield/migrator/migrations_embed.go
@@ -38,6 +38,12 @@ var m0006Up string
 //go:embed sql/0006_add_cf_constraints.down.sql
 var m0006Down string
 
+//go:embed sql/0007_add_id_column.up.sql
+var m0007Up string
+
+//go:embed sql/0007_add_id_column.down.sql
+var m0007Down string
+
 // PostgreSQL migration files
 //
 //go:embed sql/postgres/0001_init.up.sql
@@ -75,6 +81,12 @@ var pg0006Up string
 
 //go:embed sql/postgres/0006_add_cf_constraints.down.sql
 var pg0006Down string
+
+//go:embed sql/postgres/0007_add_id_column.up.sql
+var pg0007Up string
+
+//go:embed sql/postgres/0007_add_id_column.down.sql
+var pg0007Down string
 var defaultMigrations = []Migration{
 	{Version: 1, SemVer: "0.1", UpSQL: m0001Up, DownSQL: m0001Down},
 	{Version: 2, SemVer: "0.2", UpSQL: m0002Up, DownSQL: m0002Down},
@@ -82,6 +94,7 @@ var defaultMigrations = []Migration{
 	{Version: 4, SemVer: "0.4", UpSQL: m0004Up, DownSQL: m0004Down},
 	{Version: 5, SemVer: "0.5", UpSQL: m0005Up, DownSQL: m0005Down},
 	{Version: 6, SemVer: "0.6", UpSQL: m0006Up, DownSQL: m0006Down},
+	{Version: 7, SemVer: "0.7", UpSQL: m0007Up, DownSQL: m0007Down},
 }
 
 var postgresMigrations = []Migration{
@@ -91,4 +104,5 @@ var postgresMigrations = []Migration{
 	{Version: 4, SemVer: "0.4", UpSQL: pg0004Up, DownSQL: pg0004Down},
 	{Version: 5, SemVer: "0.5", UpSQL: pg0005Up, DownSQL: pg0005Down},
 	{Version: 6, SemVer: "0.6", UpSQL: pg0006Up, DownSQL: pg0006Down},
+	{Version: 7, SemVer: "0.7", UpSQL: pg0007Up, DownSQL: pg0007Down},
 }

--- a/internal/customfield/migrator/sql/0007_add_id_column.down.sql
+++ b/internal/customfield/migrator/sql/0007_add_id_column.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE custom_fields DROP INDEX idx_custom_fields_table_column;
+ALTER TABLE custom_fields DROP PRIMARY KEY;
+ALTER TABLE custom_fields DROP COLUMN id;
+ALTER TABLE custom_fields ADD PRIMARY KEY (table_name, column_name);
+DELETE FROM registry_schema_version WHERE version=7;

--- a/internal/customfield/migrator/sql/0007_add_id_column.up.sql
+++ b/internal/customfield/migrator/sql/0007_add_id_column.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE custom_fields DROP PRIMARY KEY;
+ALTER TABLE custom_fields ADD COLUMN id BIGINT AUTO_INCREMENT PRIMARY KEY FIRST;
+ALTER TABLE custom_fields ADD UNIQUE KEY idx_custom_fields_table_column (table_name, column_name);
+INSERT INTO registry_schema_version(version, semver) VALUES (7, '0.7');

--- a/internal/customfield/migrator/sql/postgres/0007_add_id_column.down.sql
+++ b/internal/customfield/migrator/sql/postgres/0007_add_id_column.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_custom_fields_table_column;
+ALTER TABLE custom_fields DROP CONSTRAINT custom_fields_pkey;
+ALTER TABLE custom_fields DROP COLUMN id;
+ALTER TABLE custom_fields ADD PRIMARY KEY (table_name, column_name);
+DELETE FROM registry_schema_version WHERE version=7;

--- a/internal/customfield/migrator/sql/postgres/0007_add_id_column.up.sql
+++ b/internal/customfield/migrator/sql/postgres/0007_add_id_column.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE custom_fields DROP CONSTRAINT custom_fields_pkey;
+ALTER TABLE custom_fields ADD COLUMN id BIGSERIAL PRIMARY KEY;
+CREATE UNIQUE INDEX idx_custom_fields_table_column ON custom_fields(table_name, column_name);
+INSERT INTO registry_schema_version(version, semver) VALUES (7, '0.7');

--- a/internal/customfield/registry/registry.go
+++ b/internal/customfield/registry/registry.go
@@ -17,6 +17,7 @@ type DBConfig struct {
 }
 
 type FieldMeta struct {
+	ID          int64        `yaml:"-"`
 	TableName   string       `yaml:"table"`
 	ColumnName  string       `yaml:"column"`
 	DataType    string       `yaml:"type"`
@@ -36,9 +37,9 @@ func LoadSQL(ctx context.Context, db *sql.DB, conf DBConfig) ([]FieldMeta, error
 	var query string
 	switch conf.Driver {
 	case "postgres":
-		query = `SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, "unique", "default", validator FROM custom_fields ORDER BY table_name, column_name`
+		query = `SELECT id, table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, "unique", "default", validator FROM custom_fields ORDER BY table_name, column_name`
 	default:
-		query = "SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, `default`, validator FROM custom_fields ORDER BY table_name, column_name"
+		query = "SELECT id, table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, `default`, validator FROM custom_fields ORDER BY table_name, column_name"
 	}
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
@@ -51,7 +52,7 @@ func LoadSQL(ctx context.Context, db *sql.DB, conf DBConfig) ([]FieldMeta, error
 		var m FieldMeta
 		var labelKey, widget, placeholderKey sql.NullString
 		var def, validator sql.NullString
-		if err := rows.Scan(&m.TableName, &m.ColumnName, &m.DataType, &labelKey, &widget, &placeholderKey, &m.Nullable, &m.Unique, &def, &validator); err != nil {
+		if err := rows.Scan(&m.ID, &m.TableName, &m.ColumnName, &m.DataType, &labelKey, &widget, &placeholderKey, &m.Nullable, &m.Unique, &def, &validator); err != nil {
 			return nil, fmt.Errorf("scan: %w", err)
 		}
 		if labelKey.Valid || widget.Valid || placeholderKey.Valid {

--- a/tests/sdk/audit_notifier_apply_test.go
+++ b/tests/sdk/audit_notifier_apply_test.go
@@ -24,7 +24,7 @@ func TestApplyHooks(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, `default`, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "default", "validator"}))
+	mock.ExpectQuery("^SELECT id, table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, `default`, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(sqlmock.NewRows([]string{"id", "table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "default", "validator"}))
 	mock.ExpectBegin()
 	mock.ExpectPrepare("INSERT INTO custom_fields").ExpectExec().WithArgs(
 		"posts", "title", "text",
@@ -59,7 +59,7 @@ func TestApplyHooksDryRun(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, `default`, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "default", "validator"}))
+	mock.ExpectQuery("^SELECT id, table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, `default`, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(sqlmock.NewRows([]string{"id", "table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "default", "validator"}))
 
 	nt := &stubNotifier{}
 	disable := false

--- a/tests/snapshot/exporter_test.go
+++ b/tests/snapshot/exporter_test.go
@@ -17,8 +17,8 @@ func TestExportLocal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
 	}
-	rows := sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "default", "validator"}).AddRow("posts", "title", "text", "", "", "", false, false, "", "")
-	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, `default`, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"id", "table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "default", "validator"}).AddRow(1, "posts", "title", "text", "", "", "", false, false, "", "")
+	mock.ExpectQuery("^SELECT id, table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, `default`, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(rows)
 	dir := t.TempDir()
 	if err := snapshot.Export(context.Background(), db, "", "mysql", snapshot.LocalDir{Path: dir}); err != nil {
 		t.Fatalf("export: %v", err)
@@ -51,8 +51,8 @@ func TestExportLocalPostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
 	}
-	rows := sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "default", "validator"}).AddRow("posts", "title", "text", "", "", "", false, false, "", "")
-	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, \"unique\", \"default\", validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"id", "table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "default", "validator"}).AddRow(1, "posts", "title", "text", "", "", "", false, false, "", "")
+	mock.ExpectQuery("^SELECT id, table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, \"unique\", \"default\", validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(rows)
 	dir := t.TempDir()
 	if err := snapshot.Export(context.Background(), db, "", "postgres", snapshot.LocalDir{Path: dir}); err != nil {
 		t.Fatalf("export: %v", err)


### PR DESCRIPTION
## Summary
- add ID field to `FieldMeta`
- update SQL queries to retrieve `id` from custom_fields
- expose new `id` column via OpenAPI
- add database migrations for mysql and postgres
- adjust tests for updated SQL queries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862c6ebd7648328b3c7941fbfbc6c9c