### PR TITLE
Fix MySQL drop column for older versions

### DIFF
--- a/internal/customfield/registry/schema.go
+++ b/internal/customfield/registry/schema.go
@@ -23,6 +23,17 @@ func escapeLiteral(v string) string {
 	return strings.ReplaceAll(v, "'", "''")
 }
 
+func quoteIdentifier(driver, ident string) string {
+	switch driver {
+	case "postgres":
+		return `"` + strings.ReplaceAll(ident, `"`, `""`) + `"`
+	case "mysql":
+		return "`" + strings.ReplaceAll(ident, "`", "``") + "`"
+	default:
+		return ident
+	}
+}
+
 var ErrDefaultNotSupported = errors.New("default not supported for column type")
 
 func supportsDefault(driver, typ string) bool {
@@ -118,17 +129,17 @@ func DropColumnSQL(ctx context.Context, db *sql.DB, driver, table, column string
 	case "mysql":
 		// MySQL < 8.0 does not support IF EXISTS for DROP COLUMN.
 		// Check whether the column exists before attempting to drop it.
-		var exists int
+		var columnCount int
 		err := db.QueryRowContext(ctx,
 			`SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
-			table, column).Scan(&exists)
+			table, column).Scan(&columnCount)
 		if err != nil {
-			return fmt.Errorf("check column: %w", err)
+			return fmt.Errorf("failed to check column existence: %w", err)
 		}
-		if exists == 0 {
+		if columnCount == 0 {
 			return nil
 		}
-		stmt = fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `%s`", table, column)
+		stmt = fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", quoteIdentifier(driver, table), quoteIdentifier(driver, column))
 	default:
 		return fmt.Errorf("unsupported driver: %s", driver)
 	}

--- a/tests/registry/unit/drop_column_test.go
+++ b/tests/registry/unit/drop_column_test.go
@@ -1,0 +1,46 @@
+package unit_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/faciam-dev/gcfm/internal/customfield/registry"
+)
+
+func TestDropColumnSQL_MySQLColumnExists(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM INFORMATION_SCHEMA.COLUMNS").
+		WithArgs("posts", "age").
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(1))
+	mock.ExpectExec("ALTER TABLE `posts` DROP COLUMN `age`").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := registry.DropColumnSQL(context.Background(), db, "mysql", "posts", "age"); err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet: %v", err)
+	}
+}
+
+func TestDropColumnSQL_MySQLColumnNotExists(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM INFORMATION_SCHEMA.COLUMNS").
+		WithArgs("posts", "age").
+		WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0))
+
+	if err := registry.DropColumnSQL(context.Background(), db, "mysql", "posts", "age"); err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- check column existence before dropping MySQL column
- drop without `IF EXISTS` to support MySQL versions prior to 8.0

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68633d146ee88328a0f783a65fe7dc19