### PR TITLE
Prefix registry tables with gcfm_

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the `bin` directory.
 
 ## fieldctl scan
 
-Scan existing database tables and store the metadata in the `custom_fields` table.
+Scan existing database tables and store the metadata in the `gcfm_custom_fields` table.
 
 ```
 fieldctl scan --db "postgres://user:pass@localhost:5432/testdb" --schema public --driver postgres

--- a/cmd/fieldctl/db/migrate.go
+++ b/cmd/fieldctl/db/migrate.go
@@ -68,7 +68,7 @@ func seedAdmin(ctx context.Context, f DBFlags, out io.Writer) error {
 	}
 	defer db.Close()
 	var count int
-	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users WHERE username='admin'`)
+	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gcfm_users WHERE username='admin'`)
 	if err := row.Scan(&count); err != nil {
 		return err
 	}
@@ -81,15 +81,15 @@ func seedAdmin(ctx context.Context, f DBFlags, out io.Writer) error {
 	switch f.Driver {
 	case "postgres":
 		if count > 0 {
-			q = `UPDATE users SET password_hash=$1 WHERE username='admin'`
+			q = `UPDATE gcfm_users SET password_hash=$1 WHERE username='admin'`
 		} else {
-			q = `INSERT INTO users (username,password_hash,role) VALUES ('admin',$1,'admin')`
+			q = `INSERT INTO gcfm_users (username,password_hash,role) VALUES ('admin',$1,'admin')`
 		}
 	default:
 		if count > 0 {
-			q = `UPDATE users SET password_hash=? WHERE username='admin'`
+			q = `UPDATE gcfm_users SET password_hash=? WHERE username='admin'`
 		} else {
-			q = `INSERT INTO users (username,password_hash,role) VALUES ('admin',?,'admin')`
+			q = `INSERT INTO gcfm_users (username,password_hash,role) VALUES ('admin',?,'admin')`
 		}
 	}
 	if _, err := db.ExecContext(ctx, q, string(hash)); err != nil {

--- a/cmd/fieldctl/user/create.go
+++ b/cmd/fieldctl/user/create.go
@@ -43,7 +43,7 @@ func NewCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_, err = db.Table("users").
+			_, err = db.Table("gcfm_users").
 				Insert(map[string]any{"username": username, "password_hash": string(hash), "role": role})
 			return err
 		},

--- a/cmd/fieldctl/user/delete.go
+++ b/cmd/fieldctl/user/delete.go
@@ -38,7 +38,7 @@ func NewDeleteCmd() *cobra.Command {
 			}
 			defer db.Close()
 
-			_, err = db.Table("users").
+			_, err = db.Table("gcfm_users").
 				Where("id", id).
 				Update(map[string]any{"is_deleted": true})
 			return err

--- a/cmd/fieldctl/user/list.go
+++ b/cmd/fieldctl/user/list.go
@@ -41,7 +41,7 @@ func NewListCmd() *cobra.Command {
 			defer db.Close()
 
 			var us []listUser
-			err = db.Table("users").
+			err = db.Table("gcfm_users").
 				Select("id", "username", "role").
 				WhereRaw("COALESCE(is_deleted,false) = :f", map[string]any{
 					"f": false,

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,6 +1,6 @@
 ---
 reservedTables:
-  - users
-  - audit_logs
-  - registry_schema_version
-  - custom_fields
+  - gcfm_users
+  - gcfm_audit_logs
+  - gcfm_registry_schema_version
+  - gcfm_custom_fields

--- a/internal/api/handler/audit.go
+++ b/internal/api/handler/audit.go
@@ -43,7 +43,7 @@ func (h *AuditHandler) list(ctx context.Context, p *auditParams) (*auditOutput, 
 	if h.Driver == "mysql" {
 		placeholder = "?"
 	}
-	query := `SELECT id, actor, action, table_name, column_name, before_json, after_json, applied_at FROM audit_logs ORDER BY id DESC LIMIT ` + placeholder
+	query := `SELECT id, actor, action, table_name, column_name, before_json, after_json, applied_at FROM gcfm_audit_logs ORDER BY id DESC LIMIT ` + placeholder
 	rows, err := h.DB.QueryContext(ctx, query, limit)
 	if err != nil {
 		return nil, err

--- a/internal/api/handler/custom_field.go
+++ b/internal/api/handler/custom_field.go
@@ -202,9 +202,9 @@ func (h *CustomFieldHandler) getField(ctx context.Context, table, column string)
 		var query string
 		switch h.Driver {
 		case "postgres":
-			query = `SELECT data_type FROM custom_fields WHERE table_name=$1 AND column_name=$2`
+			query = `SELECT data_type FROM gcfm_custom_fields WHERE table_name=$1 AND column_name=$2`
 		case "mysql":
-			query = `SELECT data_type FROM custom_fields WHERE table_name=? AND column_name=?`
+			query = `SELECT data_type FROM gcfm_custom_fields WHERE table_name=? AND column_name=?`
 		default:
 			return nil, fmt.Errorf("unsupported driver: %s", h.Driver)
 		}

--- a/internal/auth/model.go
+++ b/internal/auth/model.go
@@ -14,7 +14,7 @@ type User struct {
 	Role         string
 }
 
-// UserRepo provides access to the users table.
+// UserRepo provides access to the gcfm_users table.
 type UserRepo struct {
 	DB     *sql.DB
 	Driver string
@@ -28,9 +28,9 @@ func (r *UserRepo) GetByUsername(ctx context.Context, name string) (*User, error
 	var q string
 	switch r.Driver {
 	case "postgres":
-		q = `SELECT id, username, password_hash, role FROM users WHERE username=$1`
+		q = `SELECT id, username, password_hash, role FROM gcfm_users WHERE username=$1`
 	default:
-		q = `SELECT id, username, password_hash, role FROM users WHERE username=?`
+		q = `SELECT id, username, password_hash, role FROM gcfm_users WHERE username=?`
 	}
 	row := r.DB.QueryRowContext(ctx, q, name)
 	var u User
@@ -51,9 +51,9 @@ func (r *UserRepo) List(ctx context.Context) ([]User, error) {
 	var q string
 	switch r.Driver {
 	case "postgres":
-		q = `SELECT id, username, password_hash, role FROM users`
+		q = `SELECT id, username, password_hash, role FROM gcfm_users`
 	default:
-		q = `SELECT id, username, password_hash, role FROM users`
+		q = `SELECT id, username, password_hash, role FROM gcfm_users`
 	}
 	rows, err := r.DB.QueryContext(ctx, q)
 	if err != nil {

--- a/internal/auth/model_test.go
+++ b/internal/auth/model_test.go
@@ -17,7 +17,7 @@ func TestUserRepoList(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"id", "username", "password_hash", "role"}).
 		AddRow(1, "alice", "hash", "admin").
 		AddRow(2, "bob", "hash2", "user")
-	mock.ExpectQuery("^SELECT id, username, password_hash, role FROM users$").WillReturnRows(rows)
+	mock.ExpectQuery("^SELECT id, username, password_hash, role FROM gcfm_users$").WillReturnRows(rows)
 	users, err := repo.List(context.Background())
 	if err != nil {
 		t.Fatalf("list: %v", err)
@@ -43,7 +43,7 @@ func TestUserRepoListQueryError(t *testing.T) {
 		t.Fatalf("sqlmock: %v", err)
 	}
 	repo := &UserRepo{DB: db, Driver: "postgres"}
-	mock.ExpectQuery("^SELECT id, username, password_hash, role FROM users$").WillReturnError(errors.New("bad"))
+	mock.ExpectQuery("^SELECT id, username, password_hash, role FROM gcfm_users$").WillReturnError(errors.New("bad"))
 	if _, err := repo.List(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -57,7 +57,7 @@ func TestUserRepoListScanError(t *testing.T) {
 	repo := &UserRepo{DB: db, Driver: "postgres"}
 	rows := sqlmock.NewRows([]string{"id", "username", "password_hash", "role"}).
 		AddRow("bad", "alice", "hash", "admin")
-	mock.ExpectQuery("^SELECT id, username, password_hash, role FROM users$").WillReturnRows(rows)
+	mock.ExpectQuery("^SELECT id, username, password_hash, role FROM gcfm_users$").WillReturnRows(rows)
 	if _, err := repo.List(context.Background()); err == nil {
 		t.Fatalf("expected error")
 	}

--- a/internal/customfield/audit/recorder.go
+++ b/internal/customfield/audit/recorder.go
@@ -52,9 +52,9 @@ func (r *Recorder) Write(ctx context.Context, actor string, old, new *registry.F
 		table = old.TableName
 		column = old.ColumnName
 	}
-	q := "INSERT INTO audit_logs(actor, action, table_name, column_name, before_json, after_json) VALUES (?,?,?,?,?,?)"
+	q := "INSERT INTO gcfm_audit_logs(actor, action, table_name, column_name, before_json, after_json) VALUES (?,?,?,?,?,?)"
 	if r.Driver == "postgres" {
-		q = "INSERT INTO audit_logs(actor, action, table_name, column_name, before_json, after_json) VALUES ($1,$2,$3,$4,$5,$6)"
+		q = "INSERT INTO gcfm_audit_logs(actor, action, table_name, column_name, before_json, after_json) VALUES ($1,$2,$3,$4,$5,$6)"
 	}
 	var beforeJSON sql.NullString
 	if before != nil {

--- a/internal/customfield/migrator/migrator.go
+++ b/internal/customfield/migrator/migrator.go
@@ -43,8 +43,8 @@ func NewWithDriver(driver string) *Migrator {
 	}
 }
 
-// ErrNoVersionTable indicates registry_schema_version table is missing.
-var ErrNoVersionTable = errors.New("registry_schema_version table not found")
+// ErrNoVersionTable indicates gcfm_registry_schema_version table is missing.
+var ErrNoVersionTable = errors.New("gcfm_registry_schema_version table not found")
 
 // SemVerToInt converts a semver string to its integer version.
 func (m *Migrator) SemVerToInt(v string) (int, bool) {
@@ -59,7 +59,7 @@ func (m *Migrator) SemVerToInt(v string) (int, bool) {
 // Current returns current version (integer). If the version table doesn't exist
 // ErrNoVersionTable is returned.
 func (m *Migrator) Current(ctx context.Context, db *sql.DB) (int, error) {
-	row := db.QueryRowContext(ctx, `SELECT MAX(version) FROM registry_schema_version`)
+	row := db.QueryRowContext(ctx, `SELECT MAX(version) FROM gcfm_registry_schema_version`)
 	var v sql.NullInt64
 	if err := row.Scan(&v); err != nil {
 		if isTableMissing(err) {
@@ -111,19 +111,19 @@ func (m *Migrator) Up(ctx context.Context, db *sql.DB, target int) error {
 		if err != nil {
 			return err
 		}
-		// first time: if custom_fields table exists treat as initialized
-		if tableExists(ctx, tx, "custom_fields") {
+		// first time: if gcfm_custom_fields table exists treat as initialized
+		if tableExists(ctx, tx, "gcfm_custom_fields") {
 			if err := execAll(ctx, tx, m0001Up); err != nil {
 				tx.Rollback()
 				return err
 			}
 			// insert latest version only
-			if _, err := tx.ExecContext(ctx, `DELETE FROM registry_schema_version`); err != nil {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM gcfm_registry_schema_version`); err != nil {
 				tx.Rollback()
 				return err
 			}
 			last := m.migrations[target-1]
-			if _, err := tx.ExecContext(ctx, `INSERT INTO registry_schema_version(version, semver) VALUES (?, ?)`, last.Version, last.SemVer); err != nil {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (?, ?)`, last.Version, last.SemVer); err != nil {
 				tx.Rollback()
 				return err
 			}

--- a/internal/customfield/migrator/sql/0001_init.down.sql
+++ b/internal/customfield/migrator/sql/0001_init.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS custom_fields;
+DROP TABLE IF EXISTS gcfm_custom_fields;

--- a/internal/customfield/migrator/sql/0001_init.up.sql
+++ b/internal/customfield/migrator/sql/0001_init.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS custom_fields (
+CREATE TABLE IF NOT EXISTS gcfm_custom_fields (
     table_name VARCHAR(255) NOT NULL,
     column_name VARCHAR(255) NOT NULL,
     data_type VARCHAR(255) NOT NULL,
@@ -6,9 +6,9 @@ CREATE TABLE IF NOT EXISTS custom_fields (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (table_name, column_name)
 );
-CREATE TABLE IF NOT EXISTS registry_schema_version (
+CREATE TABLE IF NOT EXISTS gcfm_registry_schema_version (
     version INT PRIMARY KEY,
     semver VARCHAR(20) NOT NULL,
     applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-INSERT INTO registry_schema_version(version, semver) VALUES (1, '0.1');
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (1, '0.1');

--- a/internal/customfield/migrator/sql/0002_add_display.down.sql
+++ b/internal/customfield/migrator/sql/0002_add_display.down.sql
@@ -1,4 +1,4 @@
-ALTER TABLE custom_fields DROP COLUMN placeholder_key;
-ALTER TABLE custom_fields DROP COLUMN widget;
-ALTER TABLE custom_fields DROP COLUMN label_key;
-DELETE FROM registry_schema_version WHERE version=2;
+ALTER TABLE gcfm_custom_fields DROP COLUMN placeholder_key;
+ALTER TABLE gcfm_custom_fields DROP COLUMN widget;
+ALTER TABLE gcfm_custom_fields DROP COLUMN label_key;
+DELETE FROM gcfm_registry_schema_version WHERE version=2;

--- a/internal/customfield/migrator/sql/0002_add_display.up.sql
+++ b/internal/customfield/migrator/sql/0002_add_display.up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE custom_fields ADD COLUMN label_key VARCHAR(255);
-ALTER TABLE custom_fields ADD COLUMN widget VARCHAR(50);
-ALTER TABLE custom_fields ADD COLUMN placeholder_key VARCHAR(255);
-INSERT INTO registry_schema_version(version, semver) VALUES (2, '0.2');
+ALTER TABLE gcfm_custom_fields ADD COLUMN label_key VARCHAR(255);
+ALTER TABLE gcfm_custom_fields ADD COLUMN widget VARCHAR(50);
+ALTER TABLE gcfm_custom_fields ADD COLUMN placeholder_key VARCHAR(255);
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (2, '0.2');

--- a/internal/customfield/migrator/sql/0003_add_validator_plugin.down.sql
+++ b/internal/customfield/migrator/sql/0003_add_validator_plugin.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE custom_fields DROP COLUMN validator_plugin;
-DELETE FROM registry_schema_version WHERE version=3;
+ALTER TABLE gcfm_custom_fields DROP COLUMN validator_plugin;
+DELETE FROM gcfm_registry_schema_version WHERE version=3;

--- a/internal/customfield/migrator/sql/0003_add_validator_plugin.up.sql
+++ b/internal/customfield/migrator/sql/0003_add_validator_plugin.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE custom_fields ADD COLUMN validator_plugin VARCHAR(100);
-INSERT INTO registry_schema_version(version, semver) VALUES (3, '0.3');
+ALTER TABLE gcfm_custom_fields ADD COLUMN validator_plugin VARCHAR(100);
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (3, '0.3');

--- a/internal/customfield/migrator/sql/0004_add_audit_tables.down.sql
+++ b/internal/customfield/migrator/sql/0004_add_audit_tables.down.sql
@@ -1,3 +1,3 @@
-DROP TABLE IF EXISTS registry_snapshots;
-DROP TABLE IF EXISTS audit_logs;
-DELETE FROM registry_schema_version WHERE version=4;
+DROP TABLE IF EXISTS gcfm_registry_snapshots;
+DROP TABLE IF EXISTS gcfm_audit_logs;
+DELETE FROM gcfm_registry_schema_version WHERE version=4;

--- a/internal/customfield/migrator/sql/0004_add_audit_tables.up.sql
+++ b/internal/customfield/migrator/sql/0004_add_audit_tables.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS audit_logs (
+CREATE TABLE IF NOT EXISTS gcfm_audit_logs (
   id BIGINT AUTO_INCREMENT PRIMARY KEY,
   actor VARCHAR(64) NOT NULL,
   action ENUM('add','update','delete') NOT NULL,
@@ -9,11 +9,11 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE IF NOT EXISTS registry_snapshots (
+CREATE TABLE IF NOT EXISTS gcfm_registry_snapshots (
   id BIGINT AUTO_INCREMENT PRIMARY KEY,
   version INT NOT NULL,
   semver VARCHAR(20) NOT NULL,
   yaml LONGBLOB NOT NULL,
   taken_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-INSERT INTO registry_schema_version(version, semver) VALUES (4, '0.4');
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (4, '0.4');

--- a/internal/customfield/migrator/sql/0005_create_users.down.sql
+++ b/internal/customfield/migrator/sql/0005_create_users.down.sql
@@ -1,2 +1,2 @@
-DROP TABLE IF EXISTS users;
-DELETE FROM registry_schema_version WHERE version=5;
+DROP TABLE IF EXISTS gcfm_users;
+DELETE FROM gcfm_registry_schema_version WHERE version=5;

--- a/internal/customfield/migrator/sql/0005_create_users.up.sql
+++ b/internal/customfield/migrator/sql/0005_create_users.up.sql
@@ -1,10 +1,10 @@
-CREATE TABLE IF NOT EXISTS users (
+CREATE TABLE IF NOT EXISTS gcfm_users (
   id BIGINT AUTO_INCREMENT PRIMARY KEY,
   username VARCHAR(64) UNIQUE NOT NULL,
   password_hash VARCHAR(256) NOT NULL,
   role VARCHAR(32) NOT NULL DEFAULT 'admin',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-INSERT INTO users (username,password_hash) VALUES
+INSERT INTO gcfm_users (username,password_hash) VALUES
 ('admin', '$2a$12$DqM2suIU0/DuGrx3BwYI.O7rB6ig84yYI6FqdtYYdlcYNSeNBYxe');
-INSERT INTO registry_schema_version(version, semver) VALUES (5, '0.5');
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (5, '0.5');

--- a/internal/customfield/migrator/sql/0006_add_cf_constraints.down.sql
+++ b/internal/customfield/migrator/sql/0006_add_cf_constraints.down.sql
@@ -1,5 +1,5 @@
-ALTER TABLE custom_fields DROP COLUMN validator;
-ALTER TABLE custom_fields DROP COLUMN `default`;
-ALTER TABLE custom_fields DROP COLUMN `unique`;
-ALTER TABLE custom_fields DROP COLUMN nullable;
-DELETE FROM registry_schema_version WHERE version=6;
+ALTER TABLE gcfm_custom_fields DROP COLUMN validator;
+ALTER TABLE gcfm_custom_fields DROP COLUMN `default`;
+ALTER TABLE gcfm_custom_fields DROP COLUMN `unique`;
+ALTER TABLE gcfm_custom_fields DROP COLUMN nullable;
+DELETE FROM gcfm_registry_schema_version WHERE version=6;

--- a/internal/customfield/migrator/sql/0006_add_cf_constraints.up.sql
+++ b/internal/customfield/migrator/sql/0006_add_cf_constraints.up.sql
@@ -1,6 +1,6 @@
-ALTER TABLE custom_fields
+ALTER TABLE gcfm_custom_fields
     ADD COLUMN nullable BOOLEAN NOT NULL DEFAULT FALSE,
     ADD COLUMN `unique` BOOLEAN NOT NULL DEFAULT FALSE,
     ADD COLUMN `default` TEXT DEFAULT NULL,
     ADD COLUMN validator VARCHAR(64) DEFAULT NULL;
-INSERT INTO registry_schema_version(version, semver) VALUES (6, '0.6');
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (6, '0.6');

--- a/internal/customfield/migrator/sql/0007_default_flag.down.sql
+++ b/internal/customfield/migrator/sql/0007_default_flag.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE custom_fields DROP COLUMN has_default;
-ALTER TABLE custom_fields CHANGE COLUMN `default_value` `default` TEXT DEFAULT NULL;
-DELETE FROM registry_schema_version WHERE version=7;
+ALTER TABLE gcfm_custom_fields DROP COLUMN has_default;
+ALTER TABLE gcfm_custom_fields CHANGE COLUMN `default_value` `default` TEXT DEFAULT NULL;
+DELETE FROM gcfm_registry_schema_version WHERE version=7;

--- a/internal/customfield/migrator/sql/0007_default_flag.up.sql
+++ b/internal/customfield/migrator/sql/0007_default_flag.up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE custom_fields CHANGE COLUMN `default` `default_value` TEXT DEFAULT NULL;
-ALTER TABLE custom_fields ADD COLUMN has_default BOOLEAN NOT NULL DEFAULT FALSE AFTER default_value;
-UPDATE custom_fields SET has_default = TRUE WHERE default_value IS NOT NULL;
-INSERT INTO registry_schema_version(version, semver) VALUES (7, '0.7');
+ALTER TABLE gcfm_custom_fields CHANGE COLUMN `default` `default_value` TEXT DEFAULT NULL;
+ALTER TABLE gcfm_custom_fields ADD COLUMN has_default BOOLEAN NOT NULL DEFAULT FALSE AFTER default_value;
+UPDATE gcfm_custom_fields SET has_default = TRUE WHERE default_value IS NOT NULL;
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (7, '0.7');

--- a/internal/customfield/migrator/sql/postgres/0001_init.down.sql
+++ b/internal/customfield/migrator/sql/postgres/0001_init.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS custom_fields;
+DROP TABLE IF EXISTS gcfm_custom_fields;

--- a/internal/customfield/migrator/sql/postgres/0001_init.up.sql
+++ b/internal/customfield/migrator/sql/postgres/0001_init.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS custom_fields (
+CREATE TABLE IF NOT EXISTS gcfm_custom_fields (
     table_name VARCHAR(255) NOT NULL,
     column_name VARCHAR(255) NOT NULL,
     data_type VARCHAR(255) NOT NULL,
@@ -6,9 +6,9 @@ CREATE TABLE IF NOT EXISTS custom_fields (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (table_name, column_name)
 );
-CREATE TABLE IF NOT EXISTS registry_schema_version (
+CREATE TABLE IF NOT EXISTS gcfm_registry_schema_version (
     version INT PRIMARY KEY,
     semver VARCHAR(20) NOT NULL,
     applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-INSERT INTO registry_schema_version(version, semver) VALUES (1, '0.1');
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (1, '0.1');

--- a/internal/customfield/migrator/sql/postgres/0002_add_display.down.sql
+++ b/internal/customfield/migrator/sql/postgres/0002_add_display.down.sql
@@ -1,4 +1,4 @@
-ALTER TABLE custom_fields DROP COLUMN placeholder_key;
-ALTER TABLE custom_fields DROP COLUMN widget;
-ALTER TABLE custom_fields DROP COLUMN label_key;
-DELETE FROM registry_schema_version WHERE version=2;
+ALTER TABLE gcfm_custom_fields DROP COLUMN placeholder_key;
+ALTER TABLE gcfm_custom_fields DROP COLUMN widget;
+ALTER TABLE gcfm_custom_fields DROP COLUMN label_key;
+DELETE FROM gcfm_registry_schema_version WHERE version=2;

--- a/internal/customfield/migrator/sql/postgres/0002_add_display.up.sql
+++ b/internal/customfield/migrator/sql/postgres/0002_add_display.up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE custom_fields ADD COLUMN label_key VARCHAR(255);
-ALTER TABLE custom_fields ADD COLUMN widget VARCHAR(50);
-ALTER TABLE custom_fields ADD COLUMN placeholder_key VARCHAR(255);
-INSERT INTO registry_schema_version(version, semver) VALUES (2, '0.2');
+ALTER TABLE gcfm_custom_fields ADD COLUMN label_key VARCHAR(255);
+ALTER TABLE gcfm_custom_fields ADD COLUMN widget VARCHAR(50);
+ALTER TABLE gcfm_custom_fields ADD COLUMN placeholder_key VARCHAR(255);
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (2, '0.2');

--- a/internal/customfield/migrator/sql/postgres/0003_add_validator_plugin.down.sql
+++ b/internal/customfield/migrator/sql/postgres/0003_add_validator_plugin.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE custom_fields DROP COLUMN validator_plugin;
-DELETE FROM registry_schema_version WHERE version=3;
+ALTER TABLE gcfm_custom_fields DROP COLUMN validator_plugin;
+DELETE FROM gcfm_registry_schema_version WHERE version=3;

--- a/internal/customfield/migrator/sql/postgres/0003_add_validator_plugin.up.sql
+++ b/internal/customfield/migrator/sql/postgres/0003_add_validator_plugin.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE custom_fields ADD COLUMN validator_plugin VARCHAR(100);
-INSERT INTO registry_schema_version(version, semver) VALUES (3, '0.3');
+ALTER TABLE gcfm_custom_fields ADD COLUMN validator_plugin VARCHAR(100);
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (3, '0.3');

--- a/internal/customfield/migrator/sql/postgres/0004_add_audit_tables.down.sql
+++ b/internal/customfield/migrator/sql/postgres/0004_add_audit_tables.down.sql
@@ -1,3 +1,3 @@
-DROP TABLE IF EXISTS registry_snapshots;
-DROP TABLE IF EXISTS audit_logs;
-DELETE FROM registry_schema_version WHERE version=4;
+DROP TABLE IF EXISTS gcfm_registry_snapshots;
+DROP TABLE IF EXISTS gcfm_audit_logs;
+DELETE FROM gcfm_registry_schema_version WHERE version=4;

--- a/internal/customfield/migrator/sql/postgres/0004_add_audit_tables.up.sql
+++ b/internal/customfield/migrator/sql/postgres/0004_add_audit_tables.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS audit_logs (
+CREATE TABLE IF NOT EXISTS gcfm_audit_logs (
   id BIGSERIAL PRIMARY KEY,
   actor VARCHAR(64) NOT NULL,
   action VARCHAR(10) NOT NULL CHECK (action IN ('add','update','delete')),
@@ -9,11 +9,11 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE IF NOT EXISTS registry_snapshots (
+CREATE TABLE IF NOT EXISTS gcfm_registry_snapshots (
   id BIGSERIAL PRIMARY KEY,
   version INT NOT NULL,
   semver VARCHAR(20) NOT NULL,
   yaml BYTEA NOT NULL,
   taken_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-INSERT INTO registry_schema_version(version, semver) VALUES (4, '0.4');
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (4, '0.4');

--- a/internal/customfield/migrator/sql/postgres/0005_create_users.down.sql
+++ b/internal/customfield/migrator/sql/postgres/0005_create_users.down.sql
@@ -1,2 +1,2 @@
-DROP TABLE IF EXISTS users;
-DELETE FROM registry_schema_version WHERE version=5;
+DROP TABLE IF EXISTS gcfm_users;
+DELETE FROM gcfm_registry_schema_version WHERE version=5;

--- a/internal/customfield/migrator/sql/postgres/0005_create_users.up.sql
+++ b/internal/customfield/migrator/sql/postgres/0005_create_users.up.sql
@@ -1,10 +1,10 @@
-CREATE TABLE IF NOT EXISTS users (
+CREATE TABLE IF NOT EXISTS gcfm_users (
   id BIGSERIAL PRIMARY KEY,
   username VARCHAR(64) UNIQUE NOT NULL,
   password_hash VARCHAR(256) NOT NULL,
   role VARCHAR(32) NOT NULL DEFAULT 'admin',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-INSERT INTO users (username,password_hash) VALUES
+INSERT INTO gcfm_users (username,password_hash) VALUES
 ('admin', '$2a$12$DqM2suIU0/DuGrx3BwYI.O7rB6ig84yYI6FqdtYYdlcYNSeNBYxe');
-INSERT INTO registry_schema_version(version, semver) VALUES (5, '0.5');
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (5, '0.5');

--- a/internal/customfield/migrator/sql/postgres/0006_add_cf_constraints.down.sql
+++ b/internal/customfield/migrator/sql/postgres/0006_add_cf_constraints.down.sql
@@ -1,5 +1,5 @@
-ALTER TABLE custom_fields DROP COLUMN validator;
-ALTER TABLE custom_fields DROP COLUMN "default";
-ALTER TABLE custom_fields DROP COLUMN "unique";
-ALTER TABLE custom_fields DROP COLUMN nullable;
-DELETE FROM registry_schema_version WHERE version=6;
+ALTER TABLE gcfm_custom_fields DROP COLUMN validator;
+ALTER TABLE gcfm_custom_fields DROP COLUMN "default";
+ALTER TABLE gcfm_custom_fields DROP COLUMN "unique";
+ALTER TABLE gcfm_custom_fields DROP COLUMN nullable;
+DELETE FROM gcfm_registry_schema_version WHERE version=6;

--- a/internal/customfield/migrator/sql/postgres/0006_add_cf_constraints.up.sql
+++ b/internal/customfield/migrator/sql/postgres/0006_add_cf_constraints.up.sql
@@ -1,6 +1,6 @@
-ALTER TABLE custom_fields
+ALTER TABLE gcfm_custom_fields
     ADD COLUMN nullable BOOLEAN NOT NULL DEFAULT FALSE,
     ADD COLUMN "unique" BOOLEAN NOT NULL DEFAULT FALSE,
     ADD COLUMN "default" TEXT DEFAULT NULL,
     ADD COLUMN validator VARCHAR(64) DEFAULT NULL;
-INSERT INTO registry_schema_version(version, semver) VALUES (6, '0.6');
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (6, '0.6');

--- a/internal/customfield/migrator/sql/postgres/0007_default_flag.down.sql
+++ b/internal/customfield/migrator/sql/postgres/0007_default_flag.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE custom_fields DROP COLUMN has_default;
-ALTER TABLE custom_fields RENAME COLUMN default_value TO "default";
-DELETE FROM registry_schema_version WHERE version=7;
+ALTER TABLE gcfm_custom_fields DROP COLUMN has_default;
+ALTER TABLE gcfm_custom_fields RENAME COLUMN default_value TO "default";
+DELETE FROM gcfm_registry_schema_version WHERE version=7;

--- a/internal/customfield/migrator/sql/postgres/0007_default_flag.up.sql
+++ b/internal/customfield/migrator/sql/postgres/0007_default_flag.up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE custom_fields RENAME COLUMN "default" TO default_value;
-ALTER TABLE custom_fields ADD COLUMN has_default BOOLEAN NOT NULL DEFAULT FALSE;
-UPDATE custom_fields SET has_default = TRUE WHERE default_value IS NOT NULL;
-INSERT INTO registry_schema_version(version, semver) VALUES (7, '0.7');
+ALTER TABLE gcfm_custom_fields RENAME COLUMN "default" TO default_value;
+ALTER TABLE gcfm_custom_fields ADD COLUMN has_default BOOLEAN NOT NULL DEFAULT FALSE;
+UPDATE gcfm_custom_fields SET has_default = TRUE WHERE default_value IS NOT NULL;
+INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (7, '0.7');

--- a/internal/customfield/registry/registry.go
+++ b/internal/customfield/registry/registry.go
@@ -37,9 +37,9 @@ func LoadSQL(ctx context.Context, db *sql.DB, conf DBConfig) ([]FieldMeta, error
 	var query string
 	switch conf.Driver {
 	case "postgres":
-		query = `SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, "unique", has_default, default_value, validator FROM custom_fields ORDER BY table_name, column_name`
+		query = `SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, "unique", has_default, default_value, validator FROM gcfm_custom_fields ORDER BY table_name, column_name`
 	default:
-		query = "SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator FROM custom_fields ORDER BY table_name, column_name"
+		query = "SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator FROM gcfm_custom_fields ORDER BY table_name, column_name"
 	}
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
@@ -89,9 +89,9 @@ func UpsertSQL(ctx context.Context, db *sql.DB, driver string, metas []FieldMeta
 	var stmt *sql.Stmt
 	switch driver {
 	case "postgres":
-		stmt, err = tx.PrepareContext(ctx, `INSERT INTO custom_fields (table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, "unique", has_default, default_value, validator, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11, NOW(), NOW()) ON CONFLICT (table_name, column_name) DO UPDATE SET data_type=EXCLUDED.data_type, label_key=EXCLUDED.label_key, widget=EXCLUDED.widget, placeholder_key=EXCLUDED.placeholder_key, nullable=EXCLUDED.nullable, "unique"=EXCLUDED."unique", has_default=EXCLUDED.has_default, default_value=EXCLUDED.default_value, validator=EXCLUDED.validator, updated_at=NOW()`)
+		stmt, err = tx.PrepareContext(ctx, `INSERT INTO gcfm_custom_fields (table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, "unique", has_default, default_value, validator, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11, NOW(), NOW()) ON CONFLICT (table_name, column_name) DO UPDATE SET data_type=EXCLUDED.data_type, label_key=EXCLUDED.label_key, widget=EXCLUDED.widget, placeholder_key=EXCLUDED.placeholder_key, nullable=EXCLUDED.nullable, "unique"=EXCLUDED."unique", has_default=EXCLUDED.has_default, default_value=EXCLUDED.default_value, validator=EXCLUDED.validator, updated_at=NOW()`)
 	case "mysql":
-		stmt, err = tx.PrepareContext(ctx, "INSERT INTO custom_fields (table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW()) ON DUPLICATE KEY UPDATE data_type=VALUES(data_type), label_key=VALUES(label_key), widget=VALUES(widget), placeholder_key=VALUES(placeholder_key), nullable=VALUES(nullable), `unique`=VALUES(`unique`), has_default=VALUES(has_default), default_value=VALUES(default_value), validator=VALUES(validator), updated_at=NOW()")
+		stmt, err = tx.PrepareContext(ctx, "INSERT INTO gcfm_custom_fields (table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW()) ON DUPLICATE KEY UPDATE data_type=VALUES(data_type), label_key=VALUES(label_key), widget=VALUES(widget), placeholder_key=VALUES(placeholder_key), nullable=VALUES(nullable), `unique`=VALUES(`unique`), has_default=VALUES(has_default), default_value=VALUES(default_value), validator=VALUES(validator), updated_at=NOW()")
 	default:
 		tx.Rollback()
 		return fmt.Errorf("unsupported driver: %s", driver)
@@ -135,9 +135,9 @@ func DeleteSQL(ctx context.Context, db *sql.DB, driver string, metas []FieldMeta
 	var stmt *sql.Stmt
 	switch driver {
 	case "postgres":
-		stmt, err = tx.PrepareContext(ctx, `DELETE FROM custom_fields WHERE table_name = $1 AND column_name = $2`)
+		stmt, err = tx.PrepareContext(ctx, `DELETE FROM gcfm_custom_fields WHERE table_name = $1 AND column_name = $2`)
 	case "mysql":
-		stmt, err = tx.PrepareContext(ctx, `DELETE FROM custom_fields WHERE table_name = ? AND column_name = ?`)
+		stmt, err = tx.PrepareContext(ctx, `DELETE FROM gcfm_custom_fields WHERE table_name = ? AND column_name = ?`)
 	default:
 		tx.Rollback()
 		return fmt.Errorf("unsupported driver: %s", driver)

--- a/internal/driver/mysql/scanner.go
+++ b/internal/driver/mysql/scanner.go
@@ -17,7 +17,7 @@ func NewScanner(db *sql.DB) *Scanner {
 }
 
 func (s *Scanner) Scan(ctx context.Context, conf registry.DBConfig) ([]registry.FieldMeta, error) {
-	const q = `SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME != 'custom_fields' ORDER BY TABLE_NAME, ORDINAL_POSITION`
+	const q = `SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME != 'gcfm_custom_fields' ORDER BY TABLE_NAME, ORDINAL_POSITION`
 	rows, err := s.db.QueryContext(ctx, q, conf.Schema)
 	if err != nil {
 		return nil, fmt.Errorf("query: %w", err)

--- a/internal/driver/postgres/scanner.go
+++ b/internal/driver/postgres/scanner.go
@@ -17,7 +17,7 @@ func NewScanner(db *sql.DB) *Scanner {
 }
 
 func (s *Scanner) Scan(ctx context.Context, conf registry.DBConfig) ([]registry.FieldMeta, error) {
-	const q = `SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name != 'custom_fields' ORDER BY table_name, ordinal_position`
+	const q = `SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name != 'gcfm_custom_fields' ORDER BY table_name, ordinal_position`
 	rows, err := s.db.QueryContext(ctx, q, conf.Schema)
 	if err != nil {
 		return nil, fmt.Errorf("query: %w", err)

--- a/tests/api/integration/custom_field_create_mysql_test.go
+++ b/tests/api/integration/custom_field_create_mysql_test.go
@@ -75,7 +75,7 @@ func TestAPI_Create_CF_MySQL(t *testing.T) {
 	}
 
 	var count int
-	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM custom_fields WHERE table_name='posts' AND column_name='title'`)
+	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gcfm_custom_fields WHERE table_name='posts' AND column_name='title'`)
 	if err := row.Scan(&count); err != nil {
 		t.Fatalf("count: %v", err)
 	}

--- a/tests/api/integration/custom_field_create_test.go
+++ b/tests/api/integration/custom_field_create_test.go
@@ -69,7 +69,7 @@ func TestAPI_Create_CF_Integration(t *testing.T) {
 	}
 
 	var count int
-	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM custom_fields WHERE table_name='posts' AND column_name='title'`)
+	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gcfm_custom_fields WHERE table_name='posts' AND column_name='title'`)
 	if err := row.Scan(&count); err != nil {
 		t.Fatalf("count: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestAPI_Create_CF_FullPayload(t *testing.T) {
 	if !out.Nullable || out.Unique || !out.HasDefault || out.Default == nil || *out.Default != "n/a" || out.Validator != "uuid" {
 		t.Fatalf("unexpected meta: %+v", out)
 	}
-	row := db.QueryRowContext(ctx, `SELECT nullable, "unique", has_default, default_value, validator FROM custom_fields WHERE table_name='posts' AND column_name='title'`)
+	row := db.QueryRowContext(ctx, `SELECT nullable, "unique", has_default, default_value, validator FROM gcfm_custom_fields WHERE table_name='posts' AND column_name='title'`)
 	var nullable, unique, hasDef bool
 	var def, validator string
 	if err := row.Scan(&nullable, &unique, &hasDef, &def, &validator); err != nil {

--- a/tests/audit/recorder_test.go
+++ b/tests/audit/recorder_test.go
@@ -17,7 +17,7 @@ func TestRecorderWrite(t *testing.T) {
 	rec := &audit.Recorder{DB: db, Driver: "mysql"}
 	old := &registry.FieldMeta{TableName: "posts", ColumnName: "title", DataType: "text"}
 	newm := &registry.FieldMeta{TableName: "posts", ColumnName: "title", DataType: "varchar"}
-	mock.ExpectExec("INSERT INTO audit_logs").WithArgs("alice", "update", "posts", "title", sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO gcfm_audit_logs").WithArgs("alice", "update", "posts", "title", sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 	if err := rec.Write(context.Background(), "alice", old, newm); err != nil {
 		t.Fatalf("write: %v", err)
 	}

--- a/tests/integration/cli_user_postgres_test.go
+++ b/tests/integration/cli_user_postgres_test.go
@@ -64,7 +64,7 @@ func TestCLIUserCommands(t *testing.T) {
 		t.Fatalf("create: %v\n%s", err, out)
 	}
 	var count int
-	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users WHERE username='bob'`)
+	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gcfm_users WHERE username='bob'`)
 	if err := row.Scan(&count); err != nil {
 		t.Fatalf("scan bob: %v", err)
 	}

--- a/tests/registry/integration/mysql_scan_test.go
+++ b/tests/registry/integration/mysql_scan_test.go
@@ -56,7 +56,7 @@ func TestScanAndUpsert(t *testing.T) {
 		t.Fatalf("create table: %v", err)
 	}
 
-	_, err = db.ExecContext(ctx, `CREATE TABLE custom_fields (
+	_, err = db.ExecContext(ctx, `CREATE TABLE gcfm_custom_fields (
         id BIGINT PRIMARY KEY AUTO_INCREMENT,
         table_name VARCHAR(255) NOT NULL,
         column_name VARCHAR(255) NOT NULL,
@@ -80,7 +80,7 @@ func TestScanAndUpsert(t *testing.T) {
 	}
 
 	var count int
-	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM custom_fields`)
+	row := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gcfm_custom_fields`)
 	if err := row.Scan(&count); err != nil {
 		t.Fatalf("count: %v", err)
 	}

--- a/tests/registry/integration/yaml_roundtrip_test.go
+++ b/tests/registry/integration/yaml_roundtrip_test.go
@@ -56,7 +56,7 @@ func TestExportApplyRoundTrip(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `CREATE TABLE comments (id INT PRIMARY KEY AUTO_INCREMENT, message TEXT)`); err != nil {
 		t.Fatalf("create table: %v", err)
 	}
-	if _, err := db.ExecContext(ctx, `CREATE TABLE custom_fields (
+	if _, err := db.ExecContext(ctx, `CREATE TABLE gcfm_custom_fields (
         id BIGINT PRIMARY KEY AUTO_INCREMENT,
         table_name VARCHAR(255) NOT NULL,
         column_name VARCHAR(255) NOT NULL,

--- a/tests/registry/unit/migrator_test.go
+++ b/tests/registry/unit/migrator_test.go
@@ -20,7 +20,7 @@ func TestMigratorUpDownTx(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("INSERT INTO registry_schema_version").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO gcfm_registry_schema_version").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 	if err := m.Up(context.Background(), db, 1); err != nil {
 		t.Fatalf("up: %v", err)

--- a/tests/sdk/audit_notifier_apply_test.go
+++ b/tests/sdk/audit_notifier_apply_test.go
@@ -24,9 +24,9 @@ func TestApplyHooks(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "has_default", "default_value", "validator"}))
+	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator FROM gcfm_custom_fields ORDER BY table_name, column_name$").WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "has_default", "default_value", "validator"}))
 	mock.ExpectBegin()
-	mock.ExpectPrepare("INSERT INTO custom_fields").ExpectExec().WithArgs(
+	mock.ExpectPrepare("INSERT INTO gcfm_custom_fields").ExpectExec().WithArgs(
 		"posts", "title", "text",
 		sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 		sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
@@ -60,7 +60,7 @@ func TestApplyHooksDryRun(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "has_default", "default_value", "validator"}))
+	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator FROM gcfm_custom_fields ORDER BY table_name, column_name$").WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "has_default", "default_value", "validator"}))
 
 	nt := &stubNotifier{}
 	disable := false

--- a/tests/snapshot/exporter_test.go
+++ b/tests/snapshot/exporter_test.go
@@ -18,7 +18,7 @@ func TestExportLocal(t *testing.T) {
 		t.Fatalf("sqlmock: %v", err)
 	}
 	rows := sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "has_default", "default_value", "validator"}).AddRow("posts", "title", "text", "", "", "", false, false, false, "", "")
-	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(rows)
+	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, `unique`, has_default, default_value, validator FROM gcfm_custom_fields ORDER BY table_name, column_name$").WillReturnRows(rows)
 	dir := t.TempDir()
 	if err := snapshot.Export(context.Background(), db, "", "mysql", snapshot.LocalDir{Path: dir}); err != nil {
 		t.Fatalf("export: %v", err)
@@ -52,7 +52,7 @@ func TestExportLocalPostgres(t *testing.T) {
 		t.Fatalf("sqlmock: %v", err)
 	}
 	rows := sqlmock.NewRows([]string{"table_name", "column_name", "data_type", "label_key", "widget", "placeholder_key", "nullable", "unique", "has_default", "default_value", "validator"}).AddRow("posts", "title", "text", "", "", "", false, false, false, "", "")
-	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, \"unique\", has_default, default_value, validator FROM custom_fields ORDER BY table_name, column_name$").WillReturnRows(rows)
+	mock.ExpectQuery("^SELECT table_name, column_name, data_type, label_key, widget, placeholder_key, nullable, \"unique\", has_default, default_value, validator FROM gcfm_custom_fields ORDER BY table_name, column_name$").WillReturnRows(rows)
 	dir := t.TempDir()
 	if err := snapshot.Export(context.Background(), db, "", "postgres", snapshot.LocalDir{Path: dir}); err != nil {
 		t.Fatalf("export: %v", err)


### PR DESCRIPTION
## Summary
- rename registry tables to use the `gcfm_` prefix
- update SQL migrations and queries for new table names
- adjust CLI commands, handlers and tests
- update reserved tables list and docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6864063ffd4083289e5a94bdc49c7b43