### PR TITLE
Fix MySQL migration syntax

### DIFF
--- a/internal/customfield/migrator/sql/0001_init.up.sql
+++ b/internal/customfield/migrator/sql/0001_init.up.sql
@@ -11,5 +11,5 @@ CREATE TABLE IF NOT EXISTS gcfm_registry_schema_version (
     applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ALTER TABLE gcfm_registry_schema_version
-    ADD COLUMN semver VARCHAR(32);
+    ADD COLUMN IF NOT EXISTS semver VARCHAR(32);
 INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (1, '0.1');

--- a/internal/customfield/migrator/version.go
+++ b/internal/customfield/migrator/version.go
@@ -5,6 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
 )
 
 // ensureVersionTable creates the version table if it doesn't exist and inserts
@@ -20,20 +23,42 @@ func (m *Migrator) ensureVersionTable(ctx context.Context, db *sql.DB) error {
 	}
 	// ensure semver column exists; older versions may lack it
 	_, err = db.ExecContext(ctx, fmt.Sprintf(
-		`ALTER TABLE %s ADD COLUMN semver VARCHAR(32);`, tbl))
-	if err != nil {
-		msg := strings.ToLower(err.Error())
-		if !strings.Contains(msg, "duplicate column") && !strings.Contains(msg, "already exists") {
-			return err
-		}
+		`ALTER TABLE %s ADD COLUMN IF NOT EXISTS semver VARCHAR(32);`, tbl))
+	if err != nil && !isDuplicateColumnErr(err) {
+		return err
 	}
 
 	// insert the zero row if not present
-	if _, err := db.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s(version) VALUES(0)`, tbl)); err != nil {
-		msg := strings.ToLower(err.Error())
-		if !strings.Contains(msg, "duplicate") && !strings.Contains(msg, "conflict") {
-			return err
-		}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s(version) VALUES(0)`, tbl)); err != nil && !isDuplicateEntryErr(err) {
+		return err
 	}
 	return nil
+}
+
+func isDuplicateColumnErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if me, ok := err.(*mysql.MySQLError); ok {
+		return me.Number == 1060
+	}
+	if pe, ok := err.(*pq.Error); ok {
+		return string(pe.Code) == "42701"
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "duplicate column") || strings.Contains(msg, "already exists")
+}
+
+func isDuplicateEntryErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if me, ok := err.(*mysql.MySQLError); ok {
+		return me.Number == 1062
+	}
+	if pe, ok := err.(*pq.Error); ok {
+		return string(pe.Code) == "23505"
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "duplicate") || strings.Contains(msg, "conflict")
 }

--- a/tests/registry/unit/migrator_test.go
+++ b/tests/registry/unit/migrator_test.go
@@ -9,13 +9,15 @@ import (
 	"github.com/faciam-dev/gcfm/internal/customfield/migrator"
 )
 
+const expectedExecCalls = 3
+
 func TestMigratorUpDownTx(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
 	}
 	m := migrator.New()
-	for i := 0; i < 3; i++ {
+	for i := 0; i < expectedExecCalls; i++ {
 		mock.ExpectExec(".*").WillReturnResult(sqlmock.NewResult(0, 0))
 	}
 	mock.ExpectQuery("SELECT MAX\\(version\\)").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow(nil))
@@ -31,7 +33,7 @@ func TestMigratorUpDownTx(t *testing.T) {
 		t.Fatalf("unmet: %v", err)
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < expectedExecCalls; i++ {
 		mock.ExpectExec(".*").WillReturnResult(sqlmock.NewResult(0, 0))
 	}
 	mock.ExpectQuery("SELECT MAX\\(version\\)").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow(1))


### PR DESCRIPTION
## Summary
- ensure `semver` column creation works on MySQL
- adjust bootstrap migration SQL for MySQL

## Testing
- `go test ./...` *(fails: build failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d3e886ac8832882448bdba5839d23