### PR TITLE
Fix MySQL migration semver error

### DIFF
--- a/internal/customfield/migrator/sql/0001_init.up.sql
+++ b/internal/customfield/migrator/sql/0001_init.up.sql
@@ -10,6 +10,4 @@ CREATE TABLE IF NOT EXISTS gcfm_registry_schema_version (
     version INT PRIMARY KEY,
     applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-ALTER TABLE gcfm_registry_schema_version
-    ADD COLUMN semver VARCHAR(32);
 INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (1, '0.1');

--- a/tests/registry/unit/migrator_test.go
+++ b/tests/registry/unit/migrator_test.go
@@ -22,7 +22,7 @@ func TestMigratorUpDownTx(t *testing.T) {
 	}
 	mock.ExpectQuery("SELECT MAX\\(version\\)").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow(nil))
 	mock.ExpectBegin()
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 3; i++ {
 		mock.ExpectExec(".*").WillReturnResult(sqlmock.NewResult(0, 0))
 	}
 	mock.ExpectCommit()


### PR DESCRIPTION
## Summary
- remove `ALTER TABLE` that adds semver column from MySQL init migration
- update migration unit test expectations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686d4ec6f3588328bab64b828a8574c3