### PR TITLE
fix(mysql): support functional index for default target

### DIFF
--- a/internal/customfield/migrator/sql/mysql/0001_init.up.sql
+++ b/internal/customfield/migrator/sql/mysql/0001_init.up.sql
@@ -283,7 +283,10 @@ INSERT INTO gcfm_target_config_version (id, version)
   VALUES (1, REPLACE(uuid(), '-', ''))
 ON DUPLICATE KEY UPDATE version=version;
 
+-- MySQL does not support partial indexes with a WHERE clause.
+-- Use a functional index that yields a non-NULL value only when
+-- `is_default` is TRUE to ensure only one default target exists.
 CREATE UNIQUE INDEX gcfm_targets_one_default
-  ON gcfm_targets (is_default) WHERE is_default = TRUE;
+  ON gcfm_targets ((CASE WHEN is_default THEN 1 END));
 
 INSERT INTO gcfm_registry_schema_version(version, semver) VALUES (1,'0.3');


### PR DESCRIPTION
## Summary
- replace MySQL partial index using WHERE clause with functional index

## Testing
- `go test ./...` *(fails: TEST_DATABASE_URL not set for test/smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a21584e08328b59413130c831bf5